### PR TITLE
Client greeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Valid return values
 
 `{ :remote => String }` - String is the host:port of the backend server that will be proxied.  
 `{ :remote => String, :data => String }` - Same as above, but send the given data instead.  
-`{ :remote => String, :data => String, :reply => String }` - Same as above, but reply with given data back to the client
+`{ :remote => String, :data => String, :reply => String }` - Same as above, but reply with given data back to the client  
 `{ :noop => true }` - Do nothing.  
 `{ :close => true }` - Close the connection.  
 `{ :close => String }` - Close the connection after sending the String.  
@@ -176,8 +176,8 @@ to the client:
 Valid Return Values for Server Relay
 ------------------------------------
 
-`{ :proxy => String }` - String is the data to be sent to the client before proxying is enabled
-`{ :noop => true }` - Do nothing.
+`{ :proxy => String }` - String is the data to be sent to the client before proxying is enabled  
+`{ :noop => true }` - Do nothing.  
 
 Contribute
 ----------

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Valid return values
 
 `{ :remote => String }` - String is the host:port of the backend server that will be proxied.  
 `{ :remote => String, :data => String }` - Same as above, but send the given data instead.  
-`{ :remote => String, :data => String, :reply => String}` - Same as above, but reply with given data back to the client
+`{ :remote => String, :data => String, :reply => String }` - Same as above, but reply with given data back to the client
 `{ :noop => true }` - Do nothing.  
 `{ :close => true }` - Close the connection.  
 `{ :close => String }` - Close the connection after sending the String.  
@@ -154,6 +154,30 @@ of data from an already connected server:
 
 If no `:inactivity_timeout` is provided, the `proxy_inactivity_error`
 callback is never triggered.
+
+Client Greeting and Server Relay
+--------------------------------
+
+Some protocols such as SMTP require a greeting to be sent before the client
+sends any data. The server being proxied to would also likely be sending such
+a greeting, which would need to be stripped from the output being sent back
+to the client:
+
+    client_greeting "220 mx.google.com ESMTP n2sm7419324wfl.1\r\n"
+
+    proxy do |data|
+      { :remote => "mail.gmail.com:25" }
+    end
+
+    server_relay do |data|
+      { :proxy => data.gsub(/^220.*?\r?\n/, '') }
+    end
+
+Valid Return Values for Server Relay
+------------------------------------
+
+`{ :proxy => String }` - String is the data to be sent to the client before proxying is enabled
+`{ :noop => true }` - Do nothing.
 
 Contribute
 ----------

--- a/README.md
+++ b/README.md
@@ -173,6 +173,19 @@ to the client:
       { :proxy => data.gsub(/^220.*?\r?\n/, '') }
     end
 
+Client Greeting
+---------------
+
+`client_greeting` is used to present the client with a banner on connection.
+Protocols including SMTP and SSH must send a greeting to the client before
+the client will send any data.
+
+Server Relay
+------------
+
+`server_relay` is used to filter the real greeting from the server so it 
+isn't sent back to the client.
+
 Valid Return Values for Server Relay
 ------------------------------------
 

--- a/lib/proxymachine.rb
+++ b/lib/proxymachine.rb
@@ -49,6 +49,22 @@ class ProxyMachine
     @@router
   end
 
+  def self.set_greeting(greeting)
+    @@greeting = greeting
+  end
+
+  def self.greeting
+    @@greeting
+  end
+
+  def self.set_relay(block)
+    @@relay = block
+  end
+
+  def self.relay
+    @@relay
+  end
+
   def self.graceful_shutdown(signal)
     EM.stop_server($server) if $server
     LOGGER.info "Received #{signal} signal. No longer accepting new connections."
@@ -94,6 +110,8 @@ class ProxyMachine
     @@listen = "#{host}:#{port}"
     @@connect_error_callback ||= proc { |remote| }
     @@inactivity_error_callback ||= proc { |remote| }
+    @@greeting ||= nil
+    @@relay ||= nil
     self.update_procline
     EM.epoll
 
@@ -122,6 +140,14 @@ class ProxyMachine
 end
 
 module Kernel
+  def client_greeting(message)
+    ProxyMachine.set_greeting(message)
+  end
+
+  def server_relay(&block)
+    ProxyMachine.set_relay(block)
+  end
+
   def proxy(&block)
     ProxyMachine.set_router(block)
   end

--- a/lib/proxymachine/client_connection.rb
+++ b/lib/proxymachine/client_connection.rb
@@ -43,6 +43,10 @@ class ProxyMachine
     def establish_remote_server
       fail "establish_remote_server called with remote established" if @remote
       commands = ProxyMachine.router.call(@buffer.join)
+      dispatch_remote_server_commands(commands)
+    end
+
+    def dispatch_remote_server_commands(commands)
       LOGGER.info "#{peer} #{commands.inspect}"
       close_connection unless commands.instance_of?(Hash)
       if remote = commands[:remote]

--- a/lib/proxymachine/client_connection.rb
+++ b/lib/proxymachine/client_connection.rb
@@ -16,6 +16,7 @@ class ProxyMachine
       @connect_timeout = nil
       @inactivity_timeout = nil
       ProxyMachine.incr
+      send_data(ProxyMachine.greeting) if ProxyMachine.greeting
     end
 
     def peer

--- a/lib/proxymachine/client_connection.rb
+++ b/lib/proxymachine/client_connection.rb
@@ -42,22 +42,26 @@ class ProxyMachine
     # attempt is made to connect and proxy to the remote server.
     def establish_remote_server
       fail "establish_remote_server called with remote established" if @remote
-      commands = ProxyMachine.router.call(@buffer.join)
+      commands = dispatch_router(@buffer.join)
       dispatch_remote_server_commands(commands)
+    end
+
+    def dispatch_router(data)
+      ProxyMachine.router.call(data)
     end
 
     def dispatch_remote_server_commands(commands)
       LOGGER.info "#{peer} #{commands.inspect}"
       close_connection unless commands.instance_of?(Hash)
+      if data = commands[:data]
+        @buffer = [data]
+      end
+      if reply = commands[:reply]
+        send_data(reply)
+      end
       if remote = commands[:remote]
         m, host, port = *remote.match(/^(.+):(.+)$/)
         @remote = [host, port]
-        if data = commands[:data]
-          @buffer = [data]
-        end
-        if reply = commands[:reply]
-          send_data(reply)
-        end
         @connect_timeout = commands[:connect_timeout]
         @inactivity_timeout = commands[:inactivity_timeout]
         connect_to_server
@@ -68,7 +72,7 @@ class ProxyMachine
           send_data(close)
           close_connection_after_writing
         end
-      elsif commands[:noop]
+      elsif commands[:noop] || commands[:data] || commands[:reply]
         # do nothing
       else
         close_connection

--- a/lib/proxymachine/server_connection.rb
+++ b/lib/proxymachine/server_connection.rb
@@ -7,15 +7,46 @@ class ProxyMachine
     def initialize(conn)
       @client_side = conn
       @connected = false
-      @data_received = false
+      @proxy_started = false
       @timeout = nil
+      @buffer = []
+    end
+
+    def peer
+      @peer ||=
+      begin
+        port, ip = Socket.unpack_sockaddr_in(get_peername)
+        "#{ip}:#{port}"
+      end
     end
 
     def receive_data(data)
-      fail "receive_data called after raw proxy enabled" if @data_received
-      @data_received = true
-      @client_side.send_data(data)
-      proxy_incoming_to(@client_side, 10240)
+      fail "receive_data called after raw proxy enabled" if @proxy_started
+      @buffer << data
+      proxy_server_data
+    end
+
+    def proxy_server_data
+      if ProxyMachine.relay
+        commands = ProxyMachine.relay.call(@buffer.join)
+        LOGGER.info "#{peer} #{commands.inspect}"
+        close_connection unless commands.instance_of?(Hash)
+        if data = commands[:proxy]
+          @proxy_started = true
+          @buffer = []
+          @client_side.send_data(data)
+          proxy_incoming_to(@client_side, 10240)
+        elsif commands[:noop]
+          # do nothing
+        else
+          close_connection
+        end
+      else
+        @proxy_started = true
+        @buffer.each { |data| @client_side.send_data(data) }
+        @buffer = []
+        proxy_incoming_to(@client_side, 10240)
+      end
     end
 
     def connection_completed

--- a/test/configs/simple.rb
+++ b/test/configs/simple.rb
@@ -19,9 +19,15 @@ proxy do |data|
     { :remote => "localhost:9989" }
   elsif data == 'inactivity'
     { :remote => "localhost:9980", :data => 'sleep 3', :inactivity_timeout => 1 }
+  elsif data == 'server_relay'
+    { :remote => "localhost:9980" }
   else
     { :close => true }
   end
+end
+
+server_relay do |data|
+  { :proxy => data.gsub(/server_relay/, 'proxy_modified') }
 end
 
 ERROR_FILE = File.expand_path('../../proxy_error', __FILE__)

--- a/test/proxymachine_test.rb
+++ b/test/proxymachine_test.rb
@@ -40,6 +40,10 @@ class ProxymachineTest < Test::Unit::TestCase
     assert_proxy('localhost', 9990, 'g', 'g3-9980:g2')
   end
 
+  should "handle getting modified data back" do
+    assert_proxy('localhost', 9990, 'server_relay', '9980:proxy_modified')
+  end
+
   should "handle noop" do
     sock = TCPSocket.new('localhost', 9990)
     sock.write('e' * 2048)


### PR DESCRIPTION
Adds support for protocols that have a greeting sent to the client before the client responds including SMTP and SSH.

This also includes some small internal refactoring:
- Making it easier to monkey-patch `ClientConnection`
- Allowing for the `:data` and `:reply` commands to be returned from `ProxyMachine.router` in commands that don't include `:remote` to start moving in the direction of more complication client negotiations
