### PR TITLE
Small change to allow failover incase a remote turns out to be unavailable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 coverage
 rdoc
 pkg
+.idea

--- a/examples/load_balancer.rb
+++ b/examples/load_balancer.rb
@@ -8,7 +8,7 @@ require 'json'
 
 class BeeRouter
 
-  @backends = {"1.smeg.com" => ["localhost:8081", "localhost:8080"], "2.smeg.com" => "localhost:8080"}
+  @backends = {"1.smeg.com" => ["localhost:8081", "localhost:8080"], "2.smeg.com" => "localhost:8081"}
   
   def self.get_backend host
 
@@ -57,6 +57,8 @@ proxy_connect_error do |remote|
   puts "OHNOES! error connecting to #{remote}"
   puts "Now removing it"
   BeeRouter.remove_backend(remote)
+  true #to force it to recheck rather than give up - could possibly reset the retry counter and rely on this?
+  #or we return multiple remotes...
 end
 
 

--- a/examples/load_balancer.rb
+++ b/examples/load_balancer.rb
@@ -36,12 +36,6 @@ end
 
 
 proxy do |data|
-  # p data
-  #data =~ %r{^Host\:([a-z]+)\n }
-  #Host: bar.something.com:9999
-  #puts data
-  #puts "MATCH: " + $1
- # { :remote => "www.unsw.edu.au:80" }
 
   if data =~ %r{^Host:(.*)}
     name = $1

--- a/examples/load_balancer.rb
+++ b/examples/load_balancer.rb
@@ -1,0 +1,51 @@
+require 'memcache'
+require 'json'
+
+# MemCache.new 'localhost:11211', :namespace => 'my_namespace'
+# match server cookie, signon cookie?
+# if server cookie found, connect (deal with error)
+# if no cookie, lookup backends, apply statistical weight...
+
+@log = Logger.new(STDOUT)
+
+class BeeRouter
+
+  def get_backend host
+        backends = {"1.smeg.com" => ["www.unsw.edu.au:80", "news.com:80", "news.com:80"], "2.smeg.com" => "www.news.com:80"}
+        be = backends[host]
+    if be then
+      if be.class == String then
+        { :remote => be }
+      else
+        puts "hey 1"
+        {:remote => be[rand(be.size)]}
+      end
+    else
+      { :noop => true }
+    end
+  end
+  
+end
+
+
+@bee_router = BeeRouter.new
+
+proxy do |data|
+  # p data
+  #data =~ %r{^Host\:([a-z]+)\n }
+  #Host: bar.something.com:9999
+  #puts data
+  #puts "MATCH: " + $1
+ # { :remote => "www.unsw.edu.au:80" }
+
+  if data =~ %r{^Host\:(.*)}
+    name = $1
+    @log.info( "Host name: #{name.strip == '2.smeg.com'}" )
+    @bee_router.get_backend name.strip
+  else
+    { :noop => true }
+  end
+ 
+end
+
+

--- a/examples/load_balancer.rb
+++ b/examples/load_balancer.rb
@@ -1,34 +1,39 @@
-require 'memcache'
 require 'json'
 
-# MemCache.new 'localhost:11211', :namespace => 'my_namespace'
 # match server cookie, signon cookie?
 # if server cookie found, connect (deal with error)
 # if no cookie, lookup backends, apply statistical weight...
 
-@log = Logger.new(STDOUT)
+
 
 class BeeRouter
 
-  def get_backend host
-        backends = {"1.smeg.com" => ["www.unsw.edu.au:80", "news.com:80", "news.com:80"], "2.smeg.com" => "www.news.com:80"}
-        be = backends[host]
+  @backends = {"1.smeg.com" => ["localhost:8081", "localhost:8080"], "2.smeg.com" => "localhost:8080"}
+  
+  def self.get_backend host
+
+    be = @backends[host]
     if be then
       if be.class == String then
         { :remote => be }
       else
-        puts "hey 1"
         {:remote => be[rand(be.size)]}
       end
     else
       { :noop => true }
     end
   end
+
+  def self.remove_backend host
+    @backends.each do |k,v|
+      if v.instance_of?(Array) and v.size > 1
+        v.delete(host)
+      end
+    end
+  end
   
 end
 
-
-@bee_router = BeeRouter.new
 
 proxy do |data|
   # p data
@@ -38,14 +43,20 @@ proxy do |data|
   #puts "MATCH: " + $1
  # { :remote => "www.unsw.edu.au:80" }
 
-  if data =~ %r{^Host\:(.*)}
+  if data =~ %r{^Host:(.*)}
     name = $1
-    @log.info( "Host name: #{name.strip == '2.smeg.com'}" )
-    @bee_router.get_backend name.strip
+    BeeRouter.get_backend name.strip
   else
     { :noop => true }
   end
- 
+
+end
+
+
+proxy_connect_error do |remote|
+  puts "OHNOES! error connecting to #{remote}"
+  puts "Now removing it"
+  BeeRouter.remove_backend(remote)
 end
 
 

--- a/lib/proxymachine/client_connection.rb
+++ b/lib/proxymachine/client_connection.rb
@@ -107,8 +107,8 @@ class ProxyMachine
         EM.add_timer(0.1) { connect_to_server }
       else
         LOGGER.error "Connect #{@remote.join(':')} failed after ten attempts."
-        if ProxyMachine.connect_error_callback.call(@remote.join(':')) and @tries < 11
-          @tries += 1
+        if ProxyMachine.connect_error_callback.call(@remote.join(':')) == true
+          @tries = 0
           LOGGER.info "Will try and re-establish to another back end"
           @remote = nil
           establish_remote_server

--- a/lib/proxymachine/client_connection.rb
+++ b/lib/proxymachine/client_connection.rb
@@ -107,8 +107,15 @@ class ProxyMachine
         EM.add_timer(0.1) { connect_to_server }
       else
         LOGGER.error "Connect #{@remote.join(':')} failed after ten attempts."
-        close_connection
-        ProxyMachine.connect_error_callback.call(@remote.join(':'))
+        if ProxyMachine.connect_error_callback.call(@remote.join(':')) and @tries < 11
+          @tries += 1
+          LOGGER.info "Will try and re-establish to another back end"
+          @remote = nil
+          establish_remote_server
+          EM.add_timer(0.1) { connect_to_server }
+        else
+          close_connection 
+        end
       end
     end
 


### PR DESCRIPTION
I modified client_connection.rb to look at the result returned from the connect_error_callback - if true is returned - it will then start the connection process again - calling the connection block again. This means that a different backend (remote) can be given - and the client is none the wiser (not unlike what haproxy does). 

There is also a load_balancer.rb which shows this in action. I also threw in that some randomiser-based weighted load balancing (something I am doing) - I tried randomising as it means that I don't have to have any shared state regardless of how many proxymachines I have running (of course I _could_ count connections - but some other changes needed).

There may also be pictures of my dog, can't remember what else I included. 

Would love any thoughts/feedback (I have a few alternative approaches I would like to try).  
