### PR TITLE
Allow port to be nil, this permits the use of UNIX socket backends

### DIFF
--- a/lib/proxymachine/client_connection.rb
+++ b/lib/proxymachine/client_connection.rb
@@ -45,7 +45,7 @@ class ProxyMachine
       LOGGER.info "#{peer} #{commands.inspect}"
       close_connection unless commands.instance_of?(Hash)
       if remote = commands[:remote]
-        m, host, port = *remote.match(/^(.+):(.+)$/)
+        host, port = remote.split(':', 2)
         @remote = [host, port]
         if data = commands[:data]
           @buffer = [data]

--- a/proxymachine.gemspec
+++ b/proxymachine.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
 
   ## List your runtime dependencies here. Runtime dependencies are those
   ## that are needed for an end user to actually USE your code.
-  s.add_runtime_dependency(%q<eventmachine>, [">= 0.12.10"])
+  s.add_runtime_dependency(%q<eventmachine-le>, [">= 1.1.5"])
 
   ## List your development dependencies here. Development dependencies are
   ## those that are only needed during development


### PR DESCRIPTION
This change allows a UNIX socket to be specified as a backend instead of a TCP socket by omitting the port number. This follows the behaviour of event machine and is particularly useful for HTTP load balancers.
