### PR TITLE
Allow port to be nil, this permits the use of UNIX socket backends

### DIFF
--- a/lib/proxymachine/client_connection.rb
+++ b/lib/proxymachine/client_connection.rb
@@ -45,7 +45,7 @@ class ProxyMachine
       LOGGER.info "#{peer} #{commands.inspect}"
       close_connection unless commands.instance_of?(Hash)
       if remote = commands[:remote]
-        m, host, port = *remote.match(/^(.+):(.+)$/)
+        host, port = remote.split(':', 2)
         @remote = [host, port]
         if data = commands[:data]
           @buffer = [data]


### PR DESCRIPTION
This change allows a UNIX socket to be specified as a backend instead of a TCP socket by omitting the port number. This follows the behaviour of event machine and is particularly useful for HTTP load balancers.
